### PR TITLE
Switch page requests to OAI Harvesting.

### DIFF
--- a/.github/workflows/daily_update.yml
+++ b/.github/workflows/daily_update.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Create Build Environment
-      run: python3 -m pip install bs4
+      run: python3 -m pip install pyoai
     - name: Get papers
       run: python3 code/parse.py 2022 > 2022.html
     - name: Push

--- a/.github/workflows/weekly_update.yml
+++ b/.github/workflows/weekly_update.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Create Build Environment
-      run: python3 -m pip install bs4
+      run: python3 -m pip install pyoai
     - name: Get papers
       run: bash code/run.sh
     - name: Push


### PR DESCRIPTION
The current approach sends page requests for each page in a year listing. Using the OAI metadata API (https://eprint.iacr.org/rss/) would reduce the load.

run scripts were changed to `python3 -m pip install pyoai ` from  `python3 -m pip install bs4`